### PR TITLE
Improve captions

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -167,6 +167,22 @@
     header: header()
   )
 
+  // Make the "Figure/Table" text in captions bold and left align wider captions
+  show figure.caption: it => box(
+    align(left)[
+      #text(weight: "bold")[
+        #it.supplement
+        #context it.counter.display(it.numbering) 
+      ]
+      #it.separator#it.body
+    ]
+  )
+
+  // Make captions for figures containing tables display above the table
+  show figure.where(
+  kind: table
+  ): set figure.caption(position: top)
+
   set heading(numbering: "1.1")
   counter(heading).update(0)
 


### PR DESCRIPTION
- Make the caption supplement bold
- Left-align wider captions
- Display captions above tables

See example:
![image](https://github.com/user-attachments/assets/780e8d53-a134-4d18-9769-c32c72917f5c)
