### PR TITLE
Adjust template to more faithfully follow the original Chalmers template

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ not a 100% faithful one.
 
 Example usage:
 
-```
-#import "@preview/mastery-chs:0.1.0" : template
+```typst
+#import "@preview/mastery-chs:0.1.0" : template, appendices, flex-caption
 #let department = "Department of Computer Science and Engineering"
 #show: template.with(
   school: ("Chalmers University of Technology", "University of Gothenburg"),
@@ -25,6 +25,17 @@ Example usage:
 )
 
 = Introduction
-...
 
+#figure(
+  image("my_figure.svg", width: 75%),
+  caption: flex-caption(
+    [Short caption used in list of figures.],
+    [Additional elaboration on the caption presented inline with the figure.],
+  ),
+)
+
+#bibliography("refs.bib")
+#show: appendices
+
+= Some appendix
 ```

--- a/example-refs.bib
+++ b/example-refs.bib
@@ -1,0 +1,6 @@
+@phdthesis{typst,
+  title={A Programmable Markup Language for Typesetting},
+  author={M{\"a}dje, Laurenz},
+  year={2022},
+  school={2022}
+}

--- a/example.typ
+++ b/example.typ
@@ -1,0 +1,24 @@
+//#import "mastery-chs/lib.typ" : template
+#import "lib.typ" : template
+
+#show: template.with(
+// Override defaults fields here, such as title, authors, etc
+)
+
+= Some title here
+
+A reference @typst.
+
+== Subsection
+
+=== Subsubsection
+
+==== Subsubsubsection
+
+#bibliography("example-refs.bib")
+#counter(heading).update(0)
+#set heading(numbering: "A.1", supplement: [Appendix])
+
+= Some appendix here <theappendix>
+
+== wow

--- a/example.typ
+++ b/example.typ
@@ -1,5 +1,5 @@
 //#import "mastery-chs/lib.typ" : template
-#import "lib.typ" : template
+#import "lib.typ" : template, appendices
 
 #show: template.with(
 // Override defaults fields here, such as title, authors, etc
@@ -16,8 +16,7 @@ A reference @typst.
 ==== Subsubsubsection
 
 #bibliography("example-refs.bib")
-#counter(heading).update(0)
-#set heading(numbering: "A.1", supplement: [Appendix])
+#show: appendices
 
 = Some appendix here <theappendix>
 

--- a/lib.typ
+++ b/lib.typ
@@ -3,7 +3,7 @@
 #import "pages/fourthpage.typ" : fourthpage
 #import "pages/abspage.typ" : abspage
 #import "pages/ackpage.typ" : ackpage
-#import "pages/tocpage.typ" : tocpage
+#import "pages/tocpage.typ" : tocpage, flex-caption
 #import "font-sizes.typ"
 
 /// Creates a footer which displays the page counter with the given args, at the

--- a/lib.typ
+++ b/lib.typ
@@ -21,7 +21,7 @@
 /// #import "@preview/mastery-chs:0.1.0" : header
 /// #set page(header: header(text: (idx, name) => [Chapter #idx: #name]))
 /// ```
-#let header(text: (idx, name) => [#idx. #name]) = context {
+#let header(numbering: (x) => x, text: (idx, name) => [#idx. #name]) = context {
   // check if the next title page is this page
   let nextsel = selector(heading.where(level: 1)).after(here())
   let nextheaders = query(nextsel)
@@ -41,7 +41,7 @@
       if counter(heading).get().at(0) == 0 {
         prevheaders.last().body
       } else {
-        text(counter(heading).get().at(0), prevheaders.last().body)
+        text(numbering(counter(heading).get().at(0)), prevheaders.last().body)
       }
       v(-0.8em)
       line(length: 100%, stroke: black + 0.3pt)
@@ -93,6 +93,14 @@
   // skip to next odd page, reset page counter
   pagebreak(to: "odd")
   counter(page).update(1)
+}
+
+#let appendices(content) = {
+  set page(header: header(numbering: (i) => numbering("A", i)))
+  counter(heading).update(0)
+  set heading(numbering: "A.1", supplement: [Appendix])
+
+  content
 }
 
 /// Instantiates the Chalmers University of Technology template. Should be used
@@ -224,6 +232,7 @@
   show bibliography: it => {
     show heading: it => {
       pagebreak(to: "odd", weak: true)
+      counter(heading).update(0)
       align(center, {
         v(100pt)
         text(24pt, it.body)

--- a/lib.typ
+++ b/lib.typ
@@ -38,8 +38,13 @@
     let prevsel = selector(heading.where(level: 1)).before(here())
     let prevheaders = query(prevsel)
     if prevheaders.len() > 0 {
-      text(counter(heading).get().at(0), prevheaders.last().body)
-      line(length: 100%)
+      if counter(heading).get().at(0) == 0 {
+        prevheaders.last().body
+      } else {
+        text(counter(heading).get().at(0), prevheaders.last().body)
+      }
+      v(-0.8em)
+      line(length: 100%, stroke: black + 0.3pt)
     }
   }
 }
@@ -51,7 +56,7 @@
 ///
 /// Note: You most likely want to use the `template` function in a `show` rule
 /// instead, which sets the style as well
-#let pages(school, date, title, subtitle, authors, department, subject, supervisor, examiner, abstract, keywords, acknowledgements, figures, tables) = {
+#let pages(school, date, title, subtitle, authors, department, subject, supervisor, advisor, examiner, abstract, keywords, acknowledgements, figures, tables) = {
   let blankpagebreak(..args) = {
     set page(footer: none)
     pagebreak(..args)
@@ -67,7 +72,7 @@
   // fourth page (inside cover page)
   pagebreak(to: "even")
   set page(footer: footer("i"))
-  fourthpage(school, date.year(), title, subtitle, authors, department, supervisor, examiner)
+  fourthpage(school, date.year(), title, subtitle, authors, department, supervisor, advisor, examiner)
 
   // abstract page
   abspage(school, title, subtitle, authors, department, abstract, keywords)
@@ -80,7 +85,8 @@
   blankpagebreak(to: "odd")
   set page(
     footer: footer("i"),
-    header: header(text: (idx, body) => body)
+    header: header(text: (idx, body) => body),
+    header-ascent: 10%,
   )
   tocpage(figures, tables)
 
@@ -102,7 +108,6 @@
 /// ```
 ///
 /// The arguments supported are:
-/// - `font-size`: The default font size (default: 12pt)
 /// - `school`: One or multiple universities (a string or array)
 /// - `date`: The date of the thesis (default: today)
 /// - `title`: The title of the thesis
@@ -138,37 +143,48 @@
 /// function puts top-level headings (chapters) on a new odd page, adds headings
 /// to non-chapter pages, and adds a footer to all pages
 #let template(
-  font-size: 12pt,
-  school: "Chalmers University of Technology",
+  school: ("Chalmers University of Technology", "University of Gothenburg"),
   date: datetime.today(),
-  title: "My Thesis Title",
-  subtitle: "My Thesis Subtitle",
-  authors: ("Author 1", "Author 2"),
-  department: "Department of Tech",
-  subject: "Science",
-  supervisor: ("Mr Supervisor", "Department"),
-  examiner: ("Mr Examiner", "Department"),
-  abstract: [My abstract goes here],
+  title: "A Chalmers University of Technology Master's thesis template for typst",
+  subtitle: "A Subtitle that can be Very Much Longer if Necessary",
+  authors: ("Name Familyname 1", "Name Familyname 2"),
+  department: "Department of Computer Science and Engineering",
+  subject: "Computer science and engineering",
+  supervisor: ("Supervisor Supervisorsson", "Department"),
+  advisor: ("Advisor Advisorsson", "Department"),
+  examiner: ("Examiner Examinersson", "Department"),
+  abstract: [Abstract text about your project in Computer Science and Engineering],
   keywords: ("Keyword 1", "keyword 2"),
-  acknowledgements: [My acknowledgements goes here],
+  acknowledgements: [Here, you can say thank you to your supervisor(s), company advisors and other
+  people that supported you during your project.],
   figures: true,
   tables: true,
   content
 ) = {
-  set text(font-size)
   set page(
     footer: none,
     numbering: "i"
   )
+  set text(size: 12pt, font: "New Computer Modern")
+
+  show heading: set text(weight: "semibold")
+
+  show heading.where(level: 1): set text(size: 20pt)
+  show heading.where(level: 2): set text(size: 16pt)
+  show heading.where(level: 3): set text(size: 14pt)
+  show heading.where(level: 4): set text(size: 12pt)
+
 
   // prelude pages
-  pages(school, date, title, subtitle, authors, department, subject, supervisor, examiner, abstract, keywords, acknowledgements, figures, tables)
+  pages(school, date, title, subtitle, authors, department, subject, supervisor, advisor, examiner, abstract, keywords, acknowledgements, figures, tables)
+
 
   // default page style
   set page(
     footer: footer("1"),
     header: header(),
-    numbering: "1"
+    numbering: "1",
+    header-ascent: 10%,
   )
 
   // Make the "Figure/Table" text in captions bold and left align wider captions
@@ -176,7 +192,7 @@
     align(left)[
       #text(weight: "bold")[
         #it.supplement
-        #context it.counter.display(it.numbering) 
+        #context it.counter.display(it.numbering)
       ]
       #it.separator#it.body
     ]
@@ -190,15 +206,31 @@
   set heading(numbering: "1.1")
   counter(heading).update(0)
 
-  show heading.where(level: 1): it => context {
-    pagebreak(to: "odd", weak: true)
-    align(center, {
-      v(30pt)
-      text(64pt, weight: "regular", str(counter(heading).get().at(0)))
-      v(-30pt)
-      text(38pt, it.body)
-      v(20pt)
-    })
+  show heading: it => {
+    if it.level == 1 {
+      pagebreak(to: "odd", weak: true)
+      align(center, {
+        v(38pt)
+        text(50pt, weight: "regular", str(counter(heading).display()))
+        v(-30pt)
+        text(24pt, it.body)
+        v(30pt)
+      })
+    } else {
+      [#counter(heading).display() #h(text.size) #it.body]
+    }
+  }
+
+  show bibliography: it => {
+    show heading: it => {
+      pagebreak(to: "odd", weak: true)
+      align(center, {
+        v(100pt)
+        text(24pt, it.body)
+        v(30pt)
+      })
+    }
+    it
   }
 
   content

--- a/lib.typ
+++ b/lib.typ
@@ -98,7 +98,8 @@
 #let appendices(content) = {
   set page(
     footer: footer("I"),
-    header: header(numbering: (i) => numbering("A", i))
+    header: header(numbering: (i) => numbering("A", i)),
+    numbering: "I",
   )
   counter(page).update(1)
   counter(heading).update(0)

--- a/lib.typ
+++ b/lib.typ
@@ -96,7 +96,11 @@
 }
 
 #let appendices(content) = {
-  set page(header: header(numbering: (i) => numbering("A", i)))
+  set page(
+    footer: footer("I"),
+    header: header(numbering: (i) => numbering("A", i))
+  )
+  counter(page).update(1)
   counter(heading).update(0)
   set heading(numbering: "A.1", supplement: [Appendix])
 

--- a/pages/abspage.typ
+++ b/pages/abspage.typ
@@ -1,19 +1,21 @@
 #import "lib.typ" : join
 
 #let abspage(school, title, subtitle, authors, department, abstract, keywords) = {
-  set text(13pt)
   [
     #title\
     #subtitle\
-    #smallcaps(authors.join([\ ]))\
+    #upper(authors.join([\ ]))\
     #department\
     #join(school, ", ", last: " and ")
-    #v(14pt)
+    #v(8pt)
+    #show heading: set text(size: 17pt)
     #heading(outlined: false)[Abstract]
+    #v(8pt)
     #abstract
   ]
   v(1fr)
   if keywords.len() > 0 {
     [Keywords: #keywords.join(", ")]
   }
+  v(10pt)
 }

--- a/pages/ackpage.typ
+++ b/pages/ackpage.typ
@@ -1,8 +1,11 @@
 #let ackpage(date, authors, acknowledgements) = [
+  #v(20pt)
+  #show heading: set text(size: 17pt)
   #heading(outlined: false)[Acknowledgements]
+  #v(8pt)
   #acknowledgements
-  #v(30pt)
+  #v(56pt)
   #align(right)[
-    #authors.join(", "), Gothenburg, #date.display()
+    #authors.join(" and "), Gothenburg, #date.display()
   ]
 ]

--- a/pages/fourthpage.typ
+++ b/pages/fourthpage.typ
@@ -1,26 +1,26 @@
 #import "lib.typ" : join
 #import "../font-sizes.typ" : *
 
-#let fourthpage(school, year, title, subtitle, authors, department, supervisor, examiner) = {
-  grid(rows: (1fr, auto),
-    {
-      let vv = v(1cm)
-      v(4.5cm)
+#let fourthpage(school, year, title, subtitle, authors, department, supervisor, advisor, examiner) = {
+  grid(rows: (1fr, auto), {
+      let vv = v(0.8cm)
+      v(6cm)
       [
         #title\
         #subtitle\
-        #smallcaps(authors.join[\ ])
+        #upper(authors.join[\ ])
       ]
       vv
       [
-        #sym.copyright #authors.join(", "), #year
+        #sym.copyright #upper(authors.join(", ")), #year
       ]
       vv
       grid(
-        columns: (auto, auto, auto),
+        columns: (auto),
         gutter: 6pt,
-        "Supervisor:", [#supervisor.at(0),], supervisor.at(1),
-        "Examiner:", [#examiner.at(0),], examiner.at(1)
+        [Supervisor: #supervisor.at(0), #supervisor.at(1)],
+        [Advisor: #advisor.at(0), #advisor.at(1)],
+        [Examiner: #examiner.at(0), #examiner.at(1)],
       )
       vv
       [

--- a/pages/frontpage.typ
+++ b/pages/frontpage.typ
@@ -3,35 +3,44 @@
 
 #let frontpage(school, year, title, subtitle, names, department, subject) = {
   let bg = block(
-    inset: (left: 8.5%, right: 8.5%, top: 40pt, bottom: 30pt),
+    inset: (left: 60pt, right: 10pt, top: 44pt, bottom: 30pt),
     grid(
       rows: (auto, 1fr, auto),
       {
         image("../img/logos-horizontal.jpg")
+        v(1em)
         line(length: 100%, stroke: black + 1pt)
       },
       none,
       {
         line(length: 100%, stroke: black + 1pt)
-        align(left)[
+        align(left, par(leading: 0.45em)[
           #department\
           #smallcaps(join(school, [\ ]))\
           Gothenburg, Sweden, #year
-        ]
+        ])
       }
     )
   )
 
-  set page(background: bg, margin: 50pt)
-  set text(font: "Libertinus Serif")
-  v(6.969420%)
-  align(center + horizon)[
-    #huge(weight: "bold", title)
+  set page(background: bg, margin: 65pt)
+  set text(font: "New Computer Modern Sans")
+
+  [
+    #v(58.5%)
+
+    #huge(weight: "bold", par(leading: 0.45em, title))
+
+    #v(8pt)
 
     #x-large(subtitle)
 
+    #v(22pt)
+
     Master's Thesis in #subject
 
-    #smallcaps(x-large(names))
+    #v(14pt)
+
+    #upper(x-large(names))
   ]
 }

--- a/pages/frontpage.typ
+++ b/pages/frontpage.typ
@@ -37,7 +37,7 @@
 
     #v(22pt)
 
-    Master's Thesis in #subject
+    Master's thesis in #subject
 
     #v(14pt)
 

--- a/pages/thirdpage.typ
+++ b/pages/thirdpage.typ
@@ -2,7 +2,6 @@
 #import "../font-sizes.typ" : *
 
 #let thirdpage(school, year, title, subtitle, authors, department) = {
-  set text(font: "Libertinus Serif")
   set page(margin: (left: 120pt, right: 120pt, top: 90pt, bottom: 90pt))
 
   align(center + horizon,
@@ -10,14 +9,15 @@
       rows: (auto, 1fr, auto),
       large(smallcaps[Master's Thesis 2025]),
       {
-        x-large(weight: "bold", title)
-        v(0.2cm)
+        v(20pt)
+        x-large(weight: "semibold", title)
+        v(10pt)
         large(subtitle)
-        v(1cm)
-        large(smallcaps(authors))
+        v(24pt)
+        large(upper(authors))
       },
       [
-        #image("../img/logos-vertical.png", width: 35%)
+        #image("../img/logos-vertical.png", width: 45%)
         #v(5mm)
         #department\
         #smallcaps(join(school, [\ ]))\

--- a/pages/thirdpage.typ
+++ b/pages/thirdpage.typ
@@ -7,7 +7,7 @@
   align(center + horizon,
     grid(
       rows: (auto, 1fr, auto),
-      large(smallcaps[Master's Thesis 2025]),
+      large(smallcaps[Master's thesis 2025]),
       {
         v(20pt)
         x-large(weight: "semibold", title)

--- a/pages/tocpage.typ
+++ b/pages/tocpage.typ
@@ -1,26 +1,40 @@
 #let tocpage(figures, tables) = {
-  v(40pt)
-  align(center, text(24pt, heading(outlined: false)[Contents]))
-  v(20pt)
+  set page(numbering: "i")
+
+  v(100pt)
+
+  show heading: set text(size: 24pt)
+  align(center, heading(outlined: false)[Contents])
+
+  v(55pt)
+
   {
+    show outline.entry: set outline.entry(fill: repeat("." + h(6pt)))
     show outline.entry.where(level: 1): set outline.entry(fill: none)
     show outline.entry.where(level: 1): it => {
-      v(12pt)
+      v(8pt)
       strong(it)
     }
     outline(title: none, indent: auto)
   }
+
   if figures {
     pagebreak(to: "odd")
+    v(100pt)
     align(center, text(24pt)[= List of Figures])
-    outline(
-      title: none,
-      target: figure.where(kind: image),
-    )
+    [
+      #outline(
+        title: none,
+        target: figure.where(kind: image),
+      )
+    ]
   }
   if tables {
     pagebreak(to: "odd")
+    v(100pt)
     align(center, text(24pt)[= List of Tables])
-    outline(title: none, target: figure.where(kind: table))
+    [
+      #outline(title: none, target: figure.where(kind: table))
+    ]
   }
 }

--- a/pages/tocpage.typ
+++ b/pages/tocpage.typ
@@ -1,3 +1,7 @@
+#let in-outline = state("in-outline", false)
+
+#let flex-caption(short, long) = context if in-outline.get() { short } else { short + long }
+
 #let tocpage(figures, tables) = {
   set page(numbering: "i")
 
@@ -8,8 +12,13 @@
 
   v(55pt)
 
+  show outline.entry: set outline.entry(fill: repeat("." + h(6pt)))
+  show outline: it => {
+    in-outline.update(true)
+    it
+    in-outline.update(false)
+  }
   {
-    show outline.entry: set outline.entry(fill: repeat("." + h(6pt)))
     show outline.entry.where(level: 1): set outline.entry(fill: none)
     show outline.entry.where(level: 1): it => {
       v(8pt)


### PR DESCRIPTION
One can check out the first commit, build, check out the second then build again to compare changes.

This PR adds a dependency on the font New Computer Modern, which can be installed as for example `nixpkgs#newcomputermodern`. This is also the font used in the official template, although Typst font rendering is unfortunately less advanced than LaTeX and thus looks noticeably worse (missing optical font size selection).

Here are a few of the pages to compare. Left is before this PR, middle is after this PR, right is the official template.

![2025-02-27_14-23-30](https://github.com/user-attachments/assets/38e5d8a0-af8a-4982-aba6-10dddba165bf)
![2025-02-27_14-23-49](https://github.com/user-attachments/assets/a5de6d3f-3b74-4f64-83ec-c55e7c666c45)
![2025-02-27_14-24-04](https://github.com/user-attachments/assets/6e60ee8b-5c08-45a3-928b-20c4b8a52df6)
![2025-02-27_14-24-16](https://github.com/user-attachments/assets/a9fc33a5-09b1-4164-9e0e-50657700039e)
![2025-02-27_14-24-31](https://github.com/user-attachments/assets/8cfd38b2-8c53-4bb3-a96f-0b7925004a87)
![2025-02-27_14-24-48](https://github.com/user-attachments/assets/67336821-f010-49e6-836e-e0a3ca8467a0)
![2025-02-27_14-25-25](https://github.com/user-attachments/assets/414f29ea-c7b2-4888-a453-82b4f291595f)
